### PR TITLE
Package requirements to run program

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ics
+cmu_course_api
+numpy
+pandas


### PR DESCRIPTION
Created a file indicating which Python packages you need to install in order to run Schedulizer

With the requirements file, you can run 
```
pip install -r requirements.txt
```
to install all missing dependencies.